### PR TITLE
리뷰와 책에 관련된 버그 수정

### DIFF
--- a/src/main/java/com/t2m/g2nee/shop/bookset/book/dto/BookDto.java
+++ b/src/main/java/com/t2m/g2nee/shop/bookset/book/dto/BookDto.java
@@ -91,6 +91,7 @@ public class BookDto {
         private String publisherName;
         private String publisherEngName;
         private boolean isLiked;
+        private Long reviewCount;
         private Double scoreAverage;
     }
 

--- a/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepository.java
+++ b/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepository.java
@@ -20,4 +20,5 @@ public interface BookCustomRepository {
                                                                   Pageable pageable, String sort);
 
     List<BookDto.ListResponse> getRecommendBooks(List<Long> categoryIdList, Long bookId);
+    List<Long> getLowestCategoryId(List<Long> categoryIdList);
 }

--- a/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepositoryImpl.java
@@ -152,18 +152,18 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
 
           /*
             검색할 카테고리의 모든 하위 카테고리 id를 함께 가져옵니다.
-            ex) 이과 / 수학 / 미분 일때 이과를 검색 시 이과, 수학, 미분 카테고리를 가진 모든 책이 조회됩니다.
-            ex) 수학만 검색 시 수학, 미분이 카테고리를 가진 책이 검색됩니다.
+            ex) 이과 / 수학, 과학 / 미분, 적분 일때 이과를 검색 시 이과, 수학, 과학, 미분, 적분 카테고리를 가진 모든 책이 조회됩니다.
+            ex) 수학만 검색 시 수학, 미분 , 적분이 카테고리를 가진 책이 검색됩니다.
          */
         List<BookDto.ListResponse> responseList =
                 from(book)
                         .innerJoin(publisher).on(book.publisher.publisherId.eq(publisher.publisherId))
-                        .innerJoin(bookCategory).on(book.bookId.eq(bookCategory.book.bookId))
                         .innerJoin(bookFile).on(book.bookId.eq(bookFile.book.bookId))
                         .leftJoin(review).on(book.bookId.eq(review.book.bookId))
                         .leftJoin(bookLike).on(book.bookId.eq(bookLike.book.bookId))
-                        .where(eqCategoryId(bookCategory, categoryPath, categoryId)
-                                .and(bookFile.imageType.eq(BookFile.ImageType.THUMBNAIL)))
+                        .where(bookFile.imageType.eq(BookFile.ImageType.THUMBNAIL)
+                                .and(eqCategoryBookId(categoryId)
+                        ))
                         .select(Projections.fields(BookDto.ListResponse.class
                                 , book.bookId
                                 , bookFile.url.as("thumbnailImageUrl")
@@ -264,7 +264,7 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
 
         // 가중치 설정
-        MatchQueryBuilder titleQuery = QueryBuilders.matchQuery("title", keyword).boost(50);
+        MatchQueryBuilder titleQuery = QueryBuilders.matchQuery("title", keyword).boost(60);
         MatchQueryBuilder bookIndexQuery = QueryBuilders.matchQuery("bookIndex", keyword).boost(10);
         MatchQueryBuilder descriptionQuery = QueryBuilders.matchQuery("description", keyword).boost(20);
         MatchQueryBuilder contributorQuery = QueryBuilders.matchQuery("contributorName", keyword).boost(35);
@@ -313,13 +313,12 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
         List<BookDto.ListResponse> responseList =
                 from(book)
                         .innerJoin(publisher).on(book.publisher.publisherId.eq(publisher.publisherId))
-                        .innerJoin(bookCategory).on(book.bookId.eq(bookCategory.book.bookId))
                         .innerJoin(bookFile).on(book.bookId.eq(bookFile.book.bookId))
                         .innerJoin(bookContributor).on(bookContributor.book.bookId.eq(book.bookId))
                         .leftJoin(review).on(book.bookId.eq(review.book.bookId))
                         .leftJoin(bookLike).on(book.bookId.eq(bookLike.book.bookId))
                         .where(book.bookId.in(indexIdList)
-                                .and(eqCategoryId(bookCategory, categoryPath, categoryId))
+                                .and(eqCategoryBookId(categoryId))
                                 .and(bookFile.imageType.eq(BookFile.ImageType.THUMBNAIL)))
                         .select(Projections.fields(BookDto.ListResponse.class
                                 , book.bookId
@@ -529,12 +528,10 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
 
     /**
      * 카테고리 ID가 요청으로 왔을 때 필터링을 위한 메서드
-     *
-     * @param bookCategory bookCategory 객체
      * @param categoryId   카테고리 아이디
      * @return BooleanExpression
      */
-    private BooleanExpression eqCategoryId(QBookCategory bookCategory, QCategoryPath categoryPath, Long categoryId) {
+    private BooleanExpression eqCategoryBookId(Long categoryId) {
         if (categoryId == null) {
             return null;
         } else {
@@ -553,9 +550,34 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
                     .boxed()
                     .collect(Collectors.toList());
 
+            // 위 코드에서 얻은 카테고리 아이디를 가진 책의 아이디를 가져옵니다.
+            List<Long> bookIdList = from(book)
+                    .innerJoin(bookCategory).on(bookCategory.book.bookId.eq(book.bookId))
+                    .where(bookCategory.category.categoryId.in(categoryIdList))
+                    .distinct()
+                    .select(book.bookId)
+                    .fetch();
 
-            return bookCategory.category.categoryId.in(categoryIdList);
+            return book.bookId.in(bookIdList);
         }
+    }
+
+    /**
+     * 받은 카테고리 아이디에서 최하위 카테고리만 얻는 메서드
+     *
+     * @param categoryIdList 카테고리 아이디 리스트
+     * @return List<Long>
+     */
+    public List<Long> getLowestCategoryId(List<Long> categoryIdList) {
+
+        return from(category)
+                .innerJoin(categoryPath).on(categoryPath.ancestor.categoryId.eq(category.categoryId))
+                .where(category.categoryId.in(categoryIdList))
+                .select(category.categoryId)
+                .groupBy(category)
+                .having(category.count().eq(1L))
+                .fetch();
+
     }
 
     /**

--- a/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/t2m/g2nee/shop/bookset/book/repository/BookCustomRepositoryImpl.java
@@ -232,10 +232,11 @@ public class BookCustomRepositoryImpl extends QuerydslRepositorySupport implemen
                                 , book.viewCount
                                 , book.bookStatus
                                 , book.pages
+                                , review.count().as("reviewCount")
                                 , isLiked.as("isLiked")
                                 , score.as("scoreAverage")
                         ))
-                        .groupBy(book, bookLike, publisher, review)
+                        .groupBy(book, bookLike, publisher)
                         .fetchOne();
         // 조회수 증가
         addViewCount(book, bookId);

--- a/src/main/java/com/t2m/g2nee/shop/bookset/book/service/BookMgmtService.java
+++ b/src/main/java/com/t2m/g2nee/shop/bookset/book/service/BookMgmtService.java
@@ -93,7 +93,8 @@ public class BookMgmtService {
             uploadImage(details.get(i), book, tokenId, objectName, ImageType.DETAIL);
         }
         // 도서카테고리 연관 관계를 설정합니다.
-        saveBookCategory(request.getCategoryIdList(), book);
+        List<Long> lowestCategoryId = bookRepository.getLowestCategoryId(request.getCategoryIdList());
+        saveBookCategory(lowestCategoryId, book);
 
         // 도서태그 연관관계를 설정해줍니다.
         saveBookTag(book, request.getTagIdList());

--- a/src/main/java/com/t2m/g2nee/shop/like/dto/BookLikeDto.java
+++ b/src/main/java/com/t2m/g2nee/shop/like/dto/BookLikeDto.java
@@ -4,8 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/t2m/g2nee/shop/review/controller/ReviewController.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/controller/ReviewController.java
@@ -48,19 +48,14 @@ public class ReviewController {
 
     /**
      * 리뷰 수정 컨트롤러
-     *
-     * @param reviewId 리뷰 아이디
      * @param request  리뷰 정보 객체
-     * @param image    이미지
      * @return ResponseEntity<ReviewDto.Response>
      */
     @PatchMapping("/{reviewId}")
-    public ResponseEntity<ReviewDto.Response> updateReview(@PathVariable("reviewId") Long reviewId,
-                                                           @RequestPart ReviewDto.Request request,
-                                                           @RequestPart(required = false) MultipartFile image) {
+    public ResponseEntity<ReviewDto.Response> updateReview(@RequestBody ReviewDto.Request request) {
 
-        request.setReviewId(reviewId);
-        ReviewDto.Response response = reviewService.updateReview(image, request);
+
+        ReviewDto.Response response = reviewService.updateReview(request);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/t2m/g2nee/shop/review/controller/ReviewController.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +39,7 @@ public class ReviewController {
      * @return ResponseEntity<ReviewDto.Response>
      */
     @PostMapping
-    public ResponseEntity<ReviewDto.Response> postReview(@RequestPart MultipartFile image,
+    public ResponseEntity<ReviewDto.Response> postReview(@RequestPart(required = false) MultipartFile image,
                                                          @RequestPart ReviewDto.Request request) {
 
         ReviewDto.Response response = reviewService.postReview(image, request);
@@ -51,7 +52,7 @@ public class ReviewController {
      * @param request  리뷰 정보 객체
      * @return ResponseEntity<ReviewDto.Response>
      */
-    @PatchMapping("/{reviewId}")
+    @PatchMapping
     public ResponseEntity<ReviewDto.Response> updateReview(@RequestBody ReviewDto.Request request) {
 
 
@@ -68,7 +69,7 @@ public class ReviewController {
      * 확인 용이기 떄문에 응답에 id 값만 있음
      */
     @GetMapping
-    public ResponseEntity<ReviewDto.Response> getReview(@RequestBody ReviewDto.Request request) {
+    public ResponseEntity<ReviewDto.Response> getReview(@ModelAttribute ReviewDto.Request request) {
 
         ReviewDto.Response response = reviewService.getReview(request.getMemberId(), request.getBookId());
 

--- a/src/main/java/com/t2m/g2nee/shop/review/dto/ReviewDto.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/dto/ReviewDto.java
@@ -34,6 +34,7 @@ public class ReviewDto {
     }
 
     @Setter
+    @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
@@ -45,6 +46,7 @@ public class ReviewDto {
         private String imageUrl;
         private int score;
         private String nickname;
+        private Long memberId;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
     }

--- a/src/main/java/com/t2m/g2nee/shop/review/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/repository/ReviewCustomRepositoryImpl.java
@@ -35,12 +35,14 @@ public class ReviewCustomRepositoryImpl extends QuerydslRepositorySupport implem
 
         List<ReviewDto.Response> reviewList = from(review)
                 .innerJoin(member).on(review.member.customerId.eq(member.customerId))
-                .innerJoin(reviewFile).on(review.reviewId.eq(reviewFile.review.reviewId))
+                .leftJoin(reviewFile).on(review.reviewId.eq(reviewFile.review.reviewId))
                 .where(review.book.bookId.eq(bookId))
                 .select(Projections.fields(ReviewDto.Response.class
                         , review.reviewId
                         , review.content
                         , review.score
+                        , member.nickname
+                        , member.customerId.as("memberId")
                         , reviewFile.url.as("imageUrl")
                         , review.createdAt
                         , review.modifiedAt))

--- a/src/main/java/com/t2m/g2nee/shop/review/service/ReviewService.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/service/ReviewService.java
@@ -84,30 +84,16 @@ public class ReviewService {
     /**
      * 리뷰 수정 메서드
      *
-     * @param image   이미지
      * @param request 리뷰 정보 객체
      * @return ReviewDto.Response
      */
-    public ReviewDto.Response updateReview(MultipartFile image, ReviewDto.Request request) {
+    public ReviewDto.Response updateReview(ReviewDto.Request request) {
 
         Review review = reviewRepository.findById(request.getReviewId())
                 .orElseThrow(() -> new NotFoundException("리뷰 정보가 없습니다."));
         review.setModifiedAt(LocalDateTime.now());
 
-        // 이미지 파일 변경이 있을 때 실행
-        if (image != null) {
-            // storage 사용을 위한 토큰을 발급합니다.
-            String tokenId = authService.requestToken();
 
-            // 기존 이미지를 삭제합니다
-            ReviewFile reviewFile = reviewFileRepository.findByReviewId(review.getReviewId());
-            String imageUrl = reviewFile.getUrl();
-            deleteImage(imageUrl, tokenId);
-            // 기존 이미지의 연관관계를 없앱니다.
-            reviewFileRepository.deleteByReviewId(review.getReviewId());
-            // storage에 새 이미지를 업로드합니다
-            uploadImage(image, review, tokenId, review.getBook().getEngTitle(), review.getMember().getCustomerId());
-        }
         Optional.of(request.getScore()).ifPresent(review::setScore);
         Optional.ofNullable(request.getContent()).ifPresent(review::setContent);
 
@@ -199,15 +185,5 @@ public class ReviewService {
 
     }
 
-    /**
-     * 이미지 삭제 메서드
-     *
-     * @param url     이미지 url
-     * @param tokenId storage tokenId
-     */
-    private void deleteImage(String url, String tokenId) {
-
-        objectService.deleteObject(url, tokenId);
-    }
 }
 

--- a/src/main/java/com/t2m/g2nee/shop/review/service/ReviewService.java
+++ b/src/main/java/com/t2m/g2nee/shop/review/service/ReviewService.java
@@ -67,8 +67,11 @@ public class ReviewService {
 
         Review saveReview = reviewRepository.save(review);
 
-        String tokenId = authService.requestToken();
-        String url = uploadImage(image, saveReview, tokenId, book.getEngTitle(), member.getCustomerId());
+        String url = null;
+        if(image != null) {
+            String tokenId = authService.requestToken();
+            url = uploadImage(image, saveReview, tokenId, book.getEngTitle(), member.getCustomerId());
+        }
 
         return ReviewDto.Response.builder()
                 .reviewId(saveReview.getReviewId())


### PR DESCRIPTION
## #️⃣Related Issue

> 책, 리뷰

## 📝Work Detail

> 최근 merge로 인해 코드에 변동이 생겨 생긴 에러를 수정했습니다
> 책을 조회할 때 카테고리가 여러 개일 경우 동일한 책이 여러 개 조회되는 현상을 수정했습니다.
   기존에는 조회시엔  BookCategory를 Join을 하였지만 이렇게 되면 id 1인 책이 id가 1, 2인 카테고리를 가졌을 경우
   BookCategory엔 1,1 1,2 두 개의 튜플이 존재하기 때문에 Join시 동일한 책 정보가 중복되어 조회 되었습니다.

```
 List<BookDto.ListResponse> responseList =
                from(book)
                        .innerJoin(publisher).on(book.publisher.publisherId.eq(publisher.publisherId))
                        .innerJoin(bookCategory).on(bookCategory.book.bookId.eq(book.bookId)) <- 이 부분을 없애고
                        .innerJoin(bookFile).on(book.bookId.eq(bookFile.book.bookId))
                        .leftJoin(review).on(book.bookId.eq(review.book.bookId))
                        .leftJoin(bookLike).on(book.bookId.eq(bookLike.book.bookId))
                        .where(bookFile.imageType.eq(BookFile.ImageType.THUMBNAIL)
                                .and(eqCategoryBookId(categoryId) <- 여기에 카테고리에 해당하는 책들을 필터링하는 로직을 추가했습니다.
                        ))
```
